### PR TITLE
feat: adicionar conversão de xml para json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#IDEs
+.idea/

--- a/data.json
+++ b/data.json
@@ -1,0 +1,316 @@
+{
+  "xmi:XMI": {
+    "@xmlns:uml": "http://www.omg.org/spec/UML/20110701",
+    "@xmlns:xmi": "http://www.omg.org/spec/XMI/20110701",
+    "uml:Model": {
+      "@name": "Class Diagram0",
+      "@xmi:id": "_cz0YkPu8Eey8_8NuDUUJvQ",
+      "packagedElement": [
+        {
+          "@name": "Casa",
+          "@xmi:id": "_cz0Ykfu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Class",
+          "ownedAttribute": [
+            {
+              "@name": "attrCasa",
+              "@type": "_cz0_vPu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0Ykvu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@aggregation": "composite",
+              "@association": "_cz0_tfu8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0_pfu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0Yk_u8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@aggregation": "composite",
+              "@association": "_cz0_tvu8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0_pfu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0YlPu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@aggregation": "composite",
+              "@association": "_cz0_t_u8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0YnPu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0Ylfu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@aggregation": "shared",
+              "@association": "_cz0_uPu8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0_rfu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0Ylvu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@aggregation": "composite",
+              "@association": "_cz0_ufu8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0YnPu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0Yl_u8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            }
+          ],
+          "ownedOperation": [
+            {
+              "@name": "TelhadoAreaExterna2",
+              "@visibility": "public",
+              "@xmi:id": "_cz0YmPu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Operation",
+              "ownedParameter": {
+                "@direction": "return",
+                "@type": "_cz0YnPu8Eey8_8NuDUUJvQ",
+                "@xmi:id": "_cz0Ymfu8Eey8_8NuDUUJvQ",
+                "@xmi:type": "uml:Parameter"
+              }
+            },
+            {
+              "@name": "TelhadoAreaInterna2",
+              "@visibility": "public",
+              "@xmi:id": "_cz0Ymvu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Operation",
+              "ownedParameter": {
+                "@direction": "return",
+                "@type": "_cz0YnPu8Eey8_8NuDUUJvQ",
+                "@xmi:id": "_cz0Ym_u8Eey8_8NuDUUJvQ",
+                "@xmi:type": "uml:Parameter"
+              }
+            }
+          ]
+        },
+        {
+          "@name": "Telhado",
+          "@xmi:id": "_cz0YnPu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Class",
+          "ownedAttribute": [
+            {
+              "@name": "attrTelhado",
+              "@type": "_cz0_u_u8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0Ynfu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@association": "_cz0_t_u8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0Ykfu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0Ynvu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@association": "_cz0_ufu8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0Ykfu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0Yn_u8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            }
+          ],
+          "ownedOperation": [
+            {
+              "@name": "TipoTelha",
+              "@visibility": "public",
+              "@xmi:id": "_cz0_oPu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Operation",
+              "ownedParameter": {
+                "@direction": "return",
+                "@type": "_cz0_pPu8Eey8_8NuDUUJvQ",
+                "@xmi:id": "_cz0_ofu8Eey8_8NuDUUJvQ",
+                "@xmi:type": "uml:Parameter"
+              }
+            },
+            {
+              "@name": "Area",
+              "@visibility": "public",
+              "@xmi:id": "_cz0_ovu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Operation",
+              "ownedParameter": {
+                "@direction": "return",
+                "@type": "_cz0_vPu8Eey8_8NuDUUJvQ",
+                "@xmi:id": "_cz0_o_u8Eey8_8NuDUUJvQ",
+                "@xmi:type": "uml:Parameter"
+              }
+            }
+          ]
+        },
+        {
+          "@name": "TipoTelha",
+          "@xmi:id": "_cz0_pPu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Class"
+        },
+        {
+          "@name": "Parede",
+          "@xmi:id": "_cz0_pfu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Class",
+          "ownedAttribute": [
+            {
+              "@name": "attrParede",
+              "@type": "_cz0_u_u8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0_pvu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@association": "_cz0_tfu8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0Ykfu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0_p_u8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@association": "_cz0_tvu8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0Ykfu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0_qPu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            }
+          ],
+          "ownedOperation": [
+            {
+              "@name": "Altura",
+              "@visibility": "public",
+              "@xmi:id": "_cz0_qfu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Operation",
+              "ownedParameter": {
+                "@direction": "return",
+                "@type": "_cz0_vPu8Eey8_8NuDUUJvQ",
+                "@xmi:id": "_cz0_qvu8Eey8_8NuDUUJvQ",
+                "@xmi:type": "uml:Parameter"
+              }
+            },
+            {
+              "@name": "Largura",
+              "@visibility": "public",
+              "@xmi:id": "_cz0_q_u8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Operation",
+              "ownedParameter": {
+                "@direction": "return",
+                "@type": "_cz0_vPu8Eey8_8NuDUUJvQ",
+                "@xmi:id": "_cz0_rPu8Eey8_8NuDUUJvQ",
+                "@xmi:type": "uml:Parameter"
+              }
+            }
+          ]
+        },
+        {
+          "@name": "Espelho",
+          "@xmi:id": "_cz0_rfu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Class",
+          "ownedAttribute": [
+            {
+              "@name": "attrEspelho1",
+              "@type": "_cz0_u_u8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0_rvu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@name": "attrEspelho2",
+              "@type": "_cz0_u_u8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0_r_u8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            },
+            {
+              "@association": "_cz0_uPu8Eey8_8NuDUUJvQ",
+              "@name": "",
+              "@type": "_cz0Ykfu8Eey8_8NuDUUJvQ",
+              "@visibility": "private",
+              "@xmi:id": "_cz0_sPu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Property"
+            }
+          ],
+          "ownedOperation": [
+            {
+              "@name": "Altura",
+              "@visibility": "public",
+              "@xmi:id": "_cz0_sfu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Operation",
+              "ownedParameter": {
+                "@direction": "return",
+                "@type": "_cz0_vPu8Eey8_8NuDUUJvQ",
+                "@xmi:id": "_cz0_svu8Eey8_8NuDUUJvQ",
+                "@xmi:type": "uml:Parameter"
+              }
+            },
+            {
+              "@name": "Largura",
+              "@visibility": "public",
+              "@xmi:id": "_cz0_s_u8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:Operation",
+              "ownedParameter": {
+                "@direction": "return",
+                "@type": "_cz0_vPu8Eey8_8NuDUUJvQ",
+                "@xmi:id": "_cz0_tPu8Eey8_8NuDUUJvQ",
+                "@xmi:type": "uml:Parameter"
+              }
+            }
+          ]
+        },
+        {
+          "@memberEnd": "_cz0_p_u8Eey8_8NuDUUJvQ _cz0Yk_u8Eey8_8NuDUUJvQ",
+          "@name": "ParedeQuarto",
+          "@xmi:id": "_cz0_tfu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Association"
+        },
+        {
+          "@memberEnd": "_cz0_qPu8Eey8_8NuDUUJvQ _cz0YlPu8Eey8_8NuDUUJvQ",
+          "@name": "ParedeBanheiro",
+          "@xmi:id": "_cz0_tvu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Association"
+        },
+        {
+          "@memberEnd": "_cz0Ynvu8Eey8_8NuDUUJvQ _cz0Ylfu8Eey8_8NuDUUJvQ",
+          "@name": "TelhadoAreaInterna",
+          "@xmi:id": "_cz0_t_u8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Association"
+        },
+        {
+          "@memberEnd": "_cz0_sPu8Eey8_8NuDUUJvQ _cz0Ylvu8Eey8_8NuDUUJvQ",
+          "@name": "",
+          "@xmi:id": "_cz0_uPu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Association"
+        },
+        {
+          "@memberEnd": "_cz0Yn_u8Eey8_8NuDUUJvQ _cz0Yl_u8Eey8_8NuDUUJvQ",
+          "@name": "TelhadoAreaExterna",
+          "@xmi:id": "_cz0_ufu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Association"
+        },
+        {
+          "@name": "PrimitiveTypes",
+          "@xmi:id": "_cz0_uvu8Eey8_8NuDUUJvQ",
+          "@xmi:type": "uml:Package",
+          "packagedElement": [
+            {
+              "@name": "int",
+              "@xmi:id": "_cz0_u_u8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:PrimitiveType"
+            },
+            {
+              "@name": "double",
+              "@xmi:id": "_cz0_vPu8Eey8_8NuDUUJvQ",
+              "@xmi:type": "uml:PrimitiveType"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,19 @@
+import json
+import xmltodict
+
+
+with open("test.xmi") as xml_file:
+     
+    data_dict = xmltodict.parse(xml_file.read())
+    xml_file.close()
+     
+    # generate the object using json.dumps()
+    # corresponding to json data
+     
+    json_data = json.dumps(data_dict, indent=2)
+     
+    # Write the json data to output
+    # json file
+    with open("data.json", "w") as json_file:
+        json_file.write(json_data, )
+        json_file.close()

--- a/test.xmi
+++ b/test.xmi
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmlns:uml="http://www.omg.org/spec/UML/20110701" xmlns:xmi="http://www.omg.org/spec/XMI/20110701">
+  <uml:Model name="Class Diagram0" xmi:id="_cz0YkPu8Eey8_8NuDUUJvQ">
+    <packagedElement name="Casa" xmi:id="_cz0Ykfu8Eey8_8NuDUUJvQ" xmi:type="uml:Class">
+      <ownedAttribute name="attrCasa" type="_cz0_vPu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0Ykvu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute aggregation="composite" association="_cz0_tfu8Eey8_8NuDUUJvQ" name="" type="_cz0_pfu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0Yk_u8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute aggregation="composite" association="_cz0_tvu8Eey8_8NuDUUJvQ" name="" type="_cz0_pfu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0YlPu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute aggregation="composite" association="_cz0_t_u8Eey8_8NuDUUJvQ" name="" type="_cz0YnPu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0Ylfu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute aggregation="shared" association="_cz0_uPu8Eey8_8NuDUUJvQ" name="" type="_cz0_rfu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0Ylvu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute aggregation="composite" association="_cz0_ufu8Eey8_8NuDUUJvQ" name="" type="_cz0YnPu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0Yl_u8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedOperation name="TelhadoAreaExterna2" visibility="public" xmi:id="_cz0YmPu8Eey8_8NuDUUJvQ" xmi:type="uml:Operation">
+        <ownedParameter direction="return" type="_cz0YnPu8Eey8_8NuDUUJvQ" xmi:id="_cz0Ymfu8Eey8_8NuDUUJvQ" xmi:type="uml:Parameter"/>
+      </ownedOperation>
+      <ownedOperation name="TelhadoAreaInterna2" visibility="public" xmi:id="_cz0Ymvu8Eey8_8NuDUUJvQ" xmi:type="uml:Operation">
+        <ownedParameter direction="return" type="_cz0YnPu8Eey8_8NuDUUJvQ" xmi:id="_cz0Ym_u8Eey8_8NuDUUJvQ" xmi:type="uml:Parameter"/>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement name="Telhado" xmi:id="_cz0YnPu8Eey8_8NuDUUJvQ" xmi:type="uml:Class">
+      <ownedAttribute name="attrTelhado" type="_cz0_u_u8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0Ynfu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute association="_cz0_t_u8Eey8_8NuDUUJvQ" name="" type="_cz0Ykfu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0Ynvu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute association="_cz0_ufu8Eey8_8NuDUUJvQ" name="" type="_cz0Ykfu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0Yn_u8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedOperation name="TipoTelha" visibility="public" xmi:id="_cz0_oPu8Eey8_8NuDUUJvQ" xmi:type="uml:Operation">
+        <ownedParameter direction="return" type="_cz0_pPu8Eey8_8NuDUUJvQ" xmi:id="_cz0_ofu8Eey8_8NuDUUJvQ" xmi:type="uml:Parameter"/>
+      </ownedOperation>
+      <ownedOperation name="Area" visibility="public" xmi:id="_cz0_ovu8Eey8_8NuDUUJvQ" xmi:type="uml:Operation">
+        <ownedParameter direction="return" type="_cz0_vPu8Eey8_8NuDUUJvQ" xmi:id="_cz0_o_u8Eey8_8NuDUUJvQ" xmi:type="uml:Parameter"/>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement name="TipoTelha" xmi:id="_cz0_pPu8Eey8_8NuDUUJvQ" xmi:type="uml:Class"/>
+    <packagedElement name="Parede" xmi:id="_cz0_pfu8Eey8_8NuDUUJvQ" xmi:type="uml:Class">
+      <ownedAttribute name="attrParede" type="_cz0_u_u8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0_pvu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute association="_cz0_tfu8Eey8_8NuDUUJvQ" name="" type="_cz0Ykfu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0_p_u8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute association="_cz0_tvu8Eey8_8NuDUUJvQ" name="" type="_cz0Ykfu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0_qPu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedOperation name="Altura" visibility="public" xmi:id="_cz0_qfu8Eey8_8NuDUUJvQ" xmi:type="uml:Operation">
+        <ownedParameter direction="return" type="_cz0_vPu8Eey8_8NuDUUJvQ" xmi:id="_cz0_qvu8Eey8_8NuDUUJvQ" xmi:type="uml:Parameter"/>
+      </ownedOperation>
+      <ownedOperation name="Largura" visibility="public" xmi:id="_cz0_q_u8Eey8_8NuDUUJvQ" xmi:type="uml:Operation">
+        <ownedParameter direction="return" type="_cz0_vPu8Eey8_8NuDUUJvQ" xmi:id="_cz0_rPu8Eey8_8NuDUUJvQ" xmi:type="uml:Parameter"/>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement name="Espelho" xmi:id="_cz0_rfu8Eey8_8NuDUUJvQ" xmi:type="uml:Class">
+      <ownedAttribute name="attrEspelho1" type="_cz0_u_u8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0_rvu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute name="attrEspelho2" type="_cz0_u_u8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0_r_u8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedAttribute association="_cz0_uPu8Eey8_8NuDUUJvQ" name="" type="_cz0Ykfu8Eey8_8NuDUUJvQ" visibility="private" xmi:id="_cz0_sPu8Eey8_8NuDUUJvQ" xmi:type="uml:Property"/>
+      <ownedOperation name="Altura" visibility="public" xmi:id="_cz0_sfu8Eey8_8NuDUUJvQ" xmi:type="uml:Operation">
+        <ownedParameter direction="return" type="_cz0_vPu8Eey8_8NuDUUJvQ" xmi:id="_cz0_svu8Eey8_8NuDUUJvQ" xmi:type="uml:Parameter"/>
+      </ownedOperation>
+      <ownedOperation name="Largura" visibility="public" xmi:id="_cz0_s_u8Eey8_8NuDUUJvQ" xmi:type="uml:Operation">
+        <ownedParameter direction="return" type="_cz0_vPu8Eey8_8NuDUUJvQ" xmi:id="_cz0_tPu8Eey8_8NuDUUJvQ" xmi:type="uml:Parameter"/>
+      </ownedOperation>
+    </packagedElement>
+    <packagedElement memberEnd="_cz0_p_u8Eey8_8NuDUUJvQ _cz0Yk_u8Eey8_8NuDUUJvQ" name="ParedeQuarto" xmi:id="_cz0_tfu8Eey8_8NuDUUJvQ" xmi:type="uml:Association"/>
+    <packagedElement memberEnd="_cz0_qPu8Eey8_8NuDUUJvQ _cz0YlPu8Eey8_8NuDUUJvQ" name="ParedeBanheiro" xmi:id="_cz0_tvu8Eey8_8NuDUUJvQ" xmi:type="uml:Association"/>
+    <packagedElement memberEnd="_cz0Ynvu8Eey8_8NuDUUJvQ _cz0Ylfu8Eey8_8NuDUUJvQ" name="TelhadoAreaInterna" xmi:id="_cz0_t_u8Eey8_8NuDUUJvQ" xmi:type="uml:Association"/>
+    <packagedElement memberEnd="_cz0_sPu8Eey8_8NuDUUJvQ _cz0Ylvu8Eey8_8NuDUUJvQ" name="" xmi:id="_cz0_uPu8Eey8_8NuDUUJvQ" xmi:type="uml:Association"/>
+    <packagedElement memberEnd="_cz0Yn_u8Eey8_8NuDUUJvQ _cz0Yl_u8Eey8_8NuDUUJvQ" name="TelhadoAreaExterna" xmi:id="_cz0_ufu8Eey8_8NuDUUJvQ" xmi:type="uml:Association"/>
+    <packagedElement name="PrimitiveTypes" xmi:id="_cz0_uvu8Eey8_8NuDUUJvQ" xmi:type="uml:Package">
+      <packagedElement name="int" xmi:id="_cz0_u_u8Eey8_8NuDUUJvQ" xmi:type="uml:PrimitiveType"/>
+      <packagedElement name="double" xmi:id="_cz0_vPu8Eey8_8NuDUUJvQ" xmi:type="uml:PrimitiveType"/>
+    </packagedElement>
+  </uml:Model>
+</xmi:XMI>


### PR DESCRIPTION
Usamos a biblioteca xmltodict para converter um arquivo xmi para um dicionário do python, que em seguida pode ser convertido nativamente em um json.